### PR TITLE
Add User Input

### DIFF
--- a/.github/workflows/c.yml
+++ b/.github/workflows/c.yml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Run Valgrind
         run: |
-          valgrind --leak-check=full ${PWD}/bin/z ${PWD}/bin/mock_target
+          echo "run" | valgrind --leak-check=full ${PWD}/bin/z ${PWD}/bin/mock_target
 
       - name: Upload Test Coverage (Optional)
         if: success() || failure()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,13 +20,15 @@ set(CMAKE_C_EXTENSIONS OFF)
 add_compile_definitions(_POSIX_C_SOURCE=200809L)
 
 set(CMAKE_C_COMPILER gcc)
-set(CMAKE_C_FLAGS "-Wall -Wextra -pedantic")
+set(CMAKE_C_FLAGS "-Wall -Wextra -pedantic -DENABLE_TESTING_FLAG")
 set(CMAKE_C_FLAGS_DEBUG "-g -O0")
 set(CMAKE_C_FLAGS_RELEASE "-Os")
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 add_library(z_lib STATIC
     ${SRC_DIR}/debugger.c
+    ${SRC_DIR}/debugger_commands.c
+    ${SRC_DIR}/debuggee.c
 )
 
 target_include_directories(z_lib PUBLIC

--- a/include/debuggee.h
+++ b/include/debuggee.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <sys/types.h>
+
+typedef enum {
+        IDLE = 0,
+        RUNNING = 1,
+        STOPPED = 2,
+        TERMINATED = 3,
+} debuggee_state;
+
+typedef struct debuggee {
+        pid_t pid;            /**< Process ID of the debuggee */
+        const char *name;     /**< Name or path of the debuggee executable */
+        debuggee_state state; /**< Current state of the debuggee process */
+} debuggee;

--- a/include/debuggee.h
+++ b/include/debuggee.h
@@ -14,3 +14,8 @@ typedef struct debuggee {
         const char *name;     /**< Name or path of the debuggee executable */
         debuggee_state state; /**< Current state of the debuggee process */
 } debuggee;
+
+int Run(debuggee *dbgee);
+int Terminate(debuggee *dbgee);
+int Break(debuggee *dbgee);
+int Continue(debuggee *dbgee);

--- a/include/debugger.h
+++ b/include/debugger.h
@@ -1,33 +1,17 @@
 #pragma once
 
-#include <stdbool.h>
-#include <stdint.h>
-#include <sys/types.h>
+#include "debuggee.h"
 
-typedef enum {
-        TARGET_IDLE = 0,
-        TARGET_STOPPED = 1,
-        TARGET_RUNNING = 2,
-        TARGET_TERMINATED = 3
-} target_state;
-
-typedef enum {
-        DEBUGGER_IDLE = 0,
-        DEBUGGER_RUNNING = 1,
-        DEBUGGER_ATTACHED = 2
-} debugger_state;
+typedef enum { DETACHED = 1, ATTACHED = 2 } debugger_state;
 
 typedef struct debugger {
-        pid_t target_pid;        /**< Process ID of the target being debugged */
-        const char *target_name; /**< Name or path of the target executable */
-        debugger_state
-            debugger_state_flag; /**< Current state of the debugger process */
-        target_state
-            target_state_flag; /**< Current state of the target process */
+        debuggee dbgee;       /**< Debuggee that is debugged by this debugger */
+        debugger_state state; /**< Current state of the debugger process */
 } debugger;
 
+void init_dbg(debugger *dbg, const char *debuggee_name);
 int start_dbg(debugger *dbg);
 void free_dbg(debugger *dbg);
 
-int start_target(debugger *dbg);
-int trace_target(debugger *dbg);
+int start_debuggee(debugger *dbg);
+int trace_debuggee(debugger *dbg);

--- a/include/debugger.h
+++ b/include/debugger.h
@@ -9,9 +9,10 @@ typedef struct debugger {
         debugger_state state; /**< Current state of the debugger process */
 } debugger;
 
-void init_dbg(debugger *dbg, const char *debuggee_name);
-int start_dbg(debugger *dbg);
-void free_dbg(debugger *dbg);
+void init_debugger(debugger *dbg, const char *debuggee_name);
+void free_debugger(debugger *dbg);
 
 int start_debuggee(debugger *dbg);
 int trace_debuggee(debugger *dbg);
+
+int read_and_handle_user_command(debugger *dbg);

--- a/include/debugger_commands.h
+++ b/include/debugger_commands.h
@@ -1,0 +1,11 @@
+#pragma once
+
+typedef enum {
+        CMD_RUN,
+        CMD_CONTINUE,
+        CMD_STEP,
+        CMD_TERMINATE,
+        CMD_UNKNOWN
+} command_type;
+
+command_type get_command_type(const char *command);

--- a/mock_target/mock_target.c
+++ b/mock_target/mock_target.c
@@ -1,12 +1,17 @@
 #include <stdio.h>
 #include <unistd.h>
 
-int main() {
-    printf("Mock target started with PID %d\n", getpid());
-    int i = 3;
-    while (i >= 0) {
-        sleep(1);
-        i--;
-    }
-    return 0;
+int main(void) {
+        (void)(setvbuf(stdout, NULL, _IONBF, 0));
+
+        printf("Mock target started with PID %d\n", getpid());
+
+        int i = 3;
+        while (i >= 0) {
+                printf("I debug, therefore I am.\n");
+                sleep(1);
+                i--;
+        }
+
+        return 0;
 }

--- a/src/debuggee.c
+++ b/src/debuggee.c
@@ -1,0 +1,22 @@
+#include "debuggee.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/ptrace.h>
+
+int Run(debuggee *dbgee) {
+        if (dbgee->state != STOPPED) {
+                (void)(fprintf(
+                    stderr,
+                    "Debuggee is not in a stopped state. Current state: %d\n",
+                    dbgee->state));
+                return EXIT_FAILURE;
+        }
+
+        if (ptrace(PTRACE_CONT, dbgee->pid, NULL, NULL) == -1) {
+                perror("ptrace CONT");
+                return EXIT_FAILURE;
+        }
+
+        dbgee->state = RUNNING;
+        return EXIT_SUCCESS;
+}

--- a/src/debugger.c
+++ b/src/debugger.c
@@ -4,73 +4,78 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/ptrace.h>
-#include <sys/types.h>
 #include <sys/wait.h>
 #include <unistd.h>
 
+#include "debuggee.h"
 #include "debugger.h"
-#include "macros.h"
+
+void init_dbg(debugger *dbg, const char *debuggee_name) {
+        dbg->dbgee.pid = -1;
+        dbg->dbgee.name = debuggee_name;
+        dbg->dbgee.state = IDLE;
+        dbg->state = DETACHED;
+}
 
 int start_dbg(debugger *dbg) {
-        printf("Starting debugger.\n");
-        dbg->debugger_state_flag = DEBUGGER_RUNNING;
-
-        if (start_target(dbg) != 0) {
-                (void)(fprintf(stderr, "Failed to start target: %s", dbg->target_name));
+        if (start_debuggee(dbg) != 0) {
+                (void)(fprintf(stderr, "Failed to start debuggee: %s",
+                               dbg->dbgee.name));
                 return EXIT_FAILURE;
         }
 
-        if (trace_target(dbg) != 0) {
-                (void)(fprintf(stderr, "Failed to trace target: %s", dbg->target_name));
+        if (trace_debuggee(dbg) != 0) {
+                (void)(fprintf(stderr, "Failed to trace debuggee: %s",
+                               dbg->dbgee.name));
                 return EXIT_FAILURE;
         }
 
-        printf("Finished tracing target.\n");
         return EXIT_SUCCESS;
 }
 
 void free_dbg(debugger *dbg) {
-        if (dbg->debugger_state_flag == DEBUGGER_ATTACHED) {
-                if (ptrace(PTRACE_DETACH, dbg->target_pid, NULL, NULL) == -1) {
+        // Note: Because we are using PTRACE_O_EXITKILL the debuggee should also
+        // be killed when we detach
+        if (dbg->state == ATTACHED) {
+                if (ptrace(PTRACE_DETACH, dbg->dbgee.pid, NULL, NULL) == -1) {
                         (void)(fprintf(
                             stderr,
                             "Failed to detach from child with PID %d: %s\n",
-                            dbg->target_pid, strerror(errno)));
+                            dbg->dbgee.pid, strerror(errno)));
                 } else {
                         printf("Detached from child with PID: %d\n",
-                               dbg->target_pid);
+                               dbg->dbgee.pid);
                 }
         }
 
-        if ((dbg->target_state_flag == TARGET_RUNNING) ||
-            (dbg->target_state_flag == TARGET_STOPPED)) {
-                if (kill(dbg->target_pid, SIGKILL) == -1) {
+        if ((dbg->dbgee.state == RUNNING) || (dbg->dbgee.state == STOPPED)) {
+                if (kill(dbg->dbgee.pid, SIGKILL) == -1) {
                         (void)(fprintf(stderr,
                                        "Failed to kill child with PID %d: %s\n",
-                                       dbg->target_pid, strerror(errno)));
+                                       dbg->dbgee.pid, strerror(errno)));
                 } else {
                         printf("Killed child with PID: %d\nExiting...\n",
-                               dbg->target_pid);
+                               dbg->dbgee.pid);
                 }
-        } else if (dbg->target_state_flag == TARGET_TERMINATED) {
+        } else if (dbg->dbgee.state == TERMINATED) {
                 printf("Child with PID %d has already terminated.\n",
-                       dbg->target_pid);
+                       dbg->dbgee.pid);
         }
 
-        dbg->target_pid = -1;
-        dbg->debugger_state_flag = DEBUGGER_IDLE;
-        dbg->target_state_flag = TARGET_TERMINATED;
+        dbg->dbgee.pid = -1;
+        dbg->dbgee.state = TERMINATED;
+        dbg->state = DETACHED;
 }
 
 /*
- * Sets target_pid
+ * Sets dbge->dbgee.pid
  *      -> Success: Child pid
  *      -> Failure: -1
- * Sets target_state_flag
- *      -> Success: TARGET_RUNNING
- *      -> Failure: TARGET_TERMINATED
+ * Sets dbg->dbgee.state
+ *      -> Success: RUNNING
+ *      -> Failure: TERMINATED
  */
-int start_target(debugger *dbg) {
+int start_debuggee(debugger *dbg) {
         pid_t pid = fork();
         if (pid == -1) {
                 perror("fork");
@@ -82,18 +87,18 @@ int start_target(debugger *dbg) {
                         perror("ptrace");
                         exit(EXIT_FAILURE);
                 }
-                execl(dbg->target_name, dbg->target_name, NULL);
+                execl(dbg->dbgee.name, dbg->dbgee.name, NULL);
                 perror("execl");
                 exit(EXIT_FAILURE);
         } else { // Parent process
-                dbg->target_pid = pid;
-                dbg->target_state_flag = TARGET_RUNNING;
+                dbg->dbgee.pid = pid;
+                dbg->dbgee.state = RUNNING;
 
                 int status;
-                if (waitpid(dbg->target_pid, &status, 0) == -1) {
+                if (waitpid(dbg->dbgee.pid, &status, 0) == -1) {
                         perror("waitpid");
-                        dbg->target_pid = -1;
-                        dbg->target_state_flag = TARGET_TERMINATED;
+                        dbg->dbgee.pid = -1;
+                        dbg->dbgee.state = TERMINATED;
                         return EXIT_FAILURE;
                 }
 
@@ -102,49 +107,39 @@ int start_target(debugger *dbg) {
                             stderr,
                             "Child process exited prematurely with status %d\n",
                             WEXITSTATUS(status)));
-                        dbg->target_pid = -1;
-                        dbg->target_state_flag = TARGET_TERMINATED;
+                        dbg->dbgee.pid = -1;
+                        dbg->dbgee.state = TERMINATED;
                         return EXIT_FAILURE;
                 }
 
-                if (ptrace(PTRACE_SETOPTIONS, dbg->target_pid, 0,
-                           PTRACE_O_EXITKILL | PTRACE_O_TRACESYSGOOD) == -1) {
+                if (ptrace(PTRACE_SETOPTIONS, dbg->dbgee.pid, 0,
+                           PTRACE_O_EXITKILL) == -1) {
                         perror("ptrace SETOPTIONS");
-                        dbg->target_pid = -1;
-                        dbg->target_state_flag = TARGET_TERMINATED;
+                        dbg->dbgee.pid = -1;
+                        dbg->dbgee.state = TERMINATED;
                         return EXIT_FAILURE;
                 }
 
                 // In the future we might not want to continue here
-                if (ptrace(PTRACE_CONT, dbg->target_pid, NULL, NULL) == -1) {
+                if (ptrace(PTRACE_CONT, dbg->dbgee.pid, NULL, NULL) == -1) {
                         perror("ptrace CONT after SETOPTIONS");
-                        dbg->target_pid = -1;
-                        dbg->target_state_flag = TARGET_TERMINATED;
+                        dbg->dbgee.pid = -1;
+                        dbg->dbgee.state = TERMINATED;
                         return EXIT_FAILURE;
                 }
 
-                printf("Child process started with PID %d\n", dbg->target_pid);
+                printf("Child process started with PID %d\n", dbg->dbgee.pid);
         }
 
         return EXIT_SUCCESS;
 }
 
-/*
- * Sets debugger_state_flag
- *      -> Default:            DEBUGGER_ATTACHED
- *      -> Target-Termination: DEBUGGER_RUNNING
- * Sets target_state_flag
- *      -> Termination: TARGET_TERMINATED
- *      -> Stopsignal:  TARGET_STOPPED
- *      -> Continue:    TARGET_RUNNING
- */
-int trace_target(debugger *dbg) {
-        printf("Entering trace_target.\n");
-        dbg->debugger_state_flag = DEBUGGER_ATTACHED;
+int trace_debuggee(debugger *dbg) {
+        dbg->state = ATTACHED;
 
-        while (dbg->debugger_state_flag == DEBUGGER_ATTACHED) {
+        while (dbg->state == ATTACHED) {
                 int status;
-                pid_t pid = waitpid(dbg->target_pid, &status, 0);
+                pid_t pid = waitpid(dbg->dbgee.pid, &status, 0);
                 if (pid == -1) {
                         if (errno == EINTR) {
                                 continue; // Interrupted by signal, retry
@@ -156,23 +151,23 @@ int trace_target(debugger *dbg) {
                 if (WIFEXITED(status)) {
                         printf("Child %d exited with status %d.\n", pid,
                                WEXITSTATUS(status));
-                        dbg->debugger_state_flag = DEBUGGER_RUNNING;
-                        dbg->target_state_flag = TARGET_TERMINATED;
+                        dbg->state = DETACHED;
+                        dbg->dbgee.state = TERMINATED;
                         break;
                 }
 
                 if (WIFSIGNALED(status)) {
                         printf("Child %d was killed by signal %d.\n", pid,
                                WTERMSIG(status));
-                        dbg->debugger_state_flag = DEBUGGER_RUNNING;
-                        dbg->target_state_flag = TARGET_TERMINATED;
+                        dbg->state = DETACHED;
+                        dbg->dbgee.state = TERMINATED;
                         break;
                 }
 
                 if (WIFSTOPPED(status)) {
                         int sig = WSTOPSIG(status);
                         printf("Child %d stopped by signal %d.\n", pid, sig);
-                        dbg->target_state_flag = TARGET_STOPPED;
+                        dbg->dbgee.state = STOPPED;
 
                         // TODO: Handle specific signals if needed
                         // For example, handle breakpoints or single-stepping
@@ -184,7 +179,7 @@ int trace_target(debugger *dbg) {
                         }
 
                         printf("Continued child process %d.\n", pid);
-                        dbg->target_state_flag = TARGET_RUNNING;
+                        dbg->dbgee.state = RUNNING;
                 }
 
                 // TODO: Implement a mechanism to break the loop, such as

--- a/src/debugger_commands.c
+++ b/src/debugger_commands.c
@@ -1,0 +1,19 @@
+#include <string.h>
+
+#include "debugger_commands.h"
+
+command_type get_command_type(const char *command) {
+        if (strcmp(command, "run") == 0) {
+                return CMD_RUN;
+        }
+        if (strcmp(command, "continue") == 0 || strcmp(command, "cont") == 0) {
+                return CMD_CONTINUE;
+        }
+        if (strcmp(command, "step") == 0) {
+                return CMD_STEP;
+        }
+        if (strcmp(command, "quit") == 0 || strcmp(command, "exit") == 0) {
+                return CMD_TERMINATE;
+        }
+        return CMD_UNKNOWN;
+}

--- a/src/main.c
+++ b/src/main.c
@@ -2,6 +2,7 @@
 #include "macros.h"
 
 #include <stdbool.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
 
@@ -19,15 +20,21 @@ int main(int argc, char **argv) {
         }
 
         debugger dbg;
-        init_dbg(&dbg, debuggee_name);
+        init_debugger(&dbg, debuggee_name);
 
-        if (start_dbg(&dbg) != 0) {
-                free_dbg(&dbg);
+        if (start_debuggee(&dbg) != 0) {
+                (void)(fprintf(stderr, "Failed to start debuggee.\n"));
+                free_debugger(&dbg);
                 return EXIT_FAILURE;
         }
 
-        free_dbg(&dbg);
+        if (trace_debuggee(&dbg) != 0) {
+                (void)(fprintf(stderr, "Error while tracing debuggee.\n"));
+                free_debugger(&dbg);
+                return EXIT_FAILURE;
+        }
 
+        free_debugger(&dbg);
         return EXIT_SUCCESS;
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -12,18 +12,14 @@ int main(int argc, char **argv) {
                 FATAL("Usage: %s <debug_target>\n", argv[0]);
         }
 
-        const char *target_name = argv[1];
+        const char *debuggee_name = argv[1];
 
-        if (!file_exists(target_name)) {
-                FATAL("Cannot find executable %s", target_name);
+        if (!file_exists(debuggee_name)) {
+                FATAL("Cannot find executable %s", debuggee_name);
         }
 
-        debugger dbg = {
-            .target_pid = -1,
-            .target_name = target_name,
-            .debugger_state_flag = DEBUGGER_IDLE,
-            .target_state_flag = TARGET_IDLE,
-        };
+        debugger dbg;
+        init_dbg(&dbg, debuggee_name);
 
         if (start_dbg(&dbg) != 0) {
                 free_dbg(&dbg);

--- a/tests/test_debugger.c
+++ b/tests/test_debugger.c
@@ -1,12 +1,14 @@
 // NOLINTBEGIN(misc-include-cleaner)
 
-#include "debuggee.h"
-#include "debugger.h"
+#include <unistd.h>
 
 #include <criterion/criterion.h>
 #include <criterion/redirect.h>
 
 #include "test_macros.h"
+
+#include "debuggee.h"
+#include "debugger.h"
 
 #ifndef MOCK_DEBUGGEE_PATH
 #define MOCK_DEBUGGEE_PATH "../bin/mock_target"
@@ -17,9 +19,35 @@ void redirect_all_stdout(void) {
         cr_redirect_stderr();
 }
 
+static int stdin_pipe_fd[2];
+
+void setup_stdin_pipe(void) {
+        if (pipe(stdin_pipe_fd) == -1) {
+                perror("pipe");
+                exit(EXIT_FAILURE);
+        }
+
+        if (dup2(stdin_pipe_fd[0], STDIN_FILENO) == -1) {
+                perror("dup2");
+                exit(EXIT_FAILURE);
+        }
+
+        close(stdin_pipe_fd[0]);
+}
+
+Test(debugger, init_debugger_success) {
+        debugger dbg;
+        init_debugger(&dbg, MOCK_DEBUGGEE_PATH);
+
+        cr_assert_eq(dbg.dbgee.pid, -1);
+        cr_assert_eq(dbg.dbgee.name, "../bin/mock_target");
+        cr_assert_eq(dbg.dbgee.state, IDLE);
+        cr_assert_eq(dbg.state, DETACHED);
+}
+
 Test(debugger, start_debuggee_success) {
         debugger dbg;
-        init_dbg(&dbg, MOCK_DEBUGGEE_PATH);
+        init_debugger(&dbg, MOCK_DEBUGGEE_PATH);
 
         int result = start_debuggee(&dbg);
         cr_assert_eq(result, 0, "start_debuggee failed with return value %d",
@@ -29,17 +57,22 @@ Test(debugger, start_debuggee_success) {
         cr_assert_eq(dbg.dbgee.state, RUNNING,
                      "Debuggee state flag not set to RUNNING.");
 
-        free_dbg(&dbg);
+        free_debugger(&dbg);
 }
 
-Test(debugger, trace_debuggee_success, .init = redirect_all_stdout) {
+Test(debugger, trace_debuggee_success, .init = setup_stdin_pipe) {
         debugger dbg;
-        init_dbg(&dbg, MOCK_DEBUGGEE_PATH);
+        init_debugger(&dbg, MOCK_DEBUGGEE_PATH);
 
         int start_result = start_debuggee(&dbg);
         cr_assert_eq(start_result, 0,
                      "start_debuggee failed with return value %d",
                      start_result);
+
+        const char *input = "run\n";
+        ssize_t bytes_written = write(stdin_pipe_fd[1], input, strlen(input));
+        cr_assert_eq(bytes_written, (ssize_t)strlen(input),
+                     "Failed to write to stdin");
 
         int trace_result = trace_debuggee(&dbg);
         cr_assert_eq(trace_result, 0,
@@ -53,27 +86,29 @@ Test(debugger, trace_debuggee_success, .init = redirect_all_stdout) {
             dbg.dbgee.state, TERMINATED,
             "Debuggee state should be TERMINATED after trace_debuggee.");
 
-        free_dbg(&dbg);
+        free_debugger(&dbg);
 }
 
-Test(debugger, free_dbg_kill_running_debuggee, .init = redirect_all_stdout) {
+Test(debugger, free_debugger_kill_running_debuggee,
+     .init = redirect_all_stdout) {
         debugger dbg;
-        init_dbg(&dbg, MOCK_DEBUGGEE_PATH);
+        init_debugger(&dbg, MOCK_DEBUGGEE_PATH);
 
         int start_result = start_debuggee(&dbg);
         cr_assert_eq(start_result, 0,
                      "start_debuggee failed with return value %d",
                      start_result);
 
-        free_dbg(&dbg);
+        free_debugger(&dbg);
 
         cr_assert_eq(dbg.dbgee.pid, -1,
-                     "Debuggee PID should be reset after free_dbg.");
+                     "Debuggee PID should be reset after free_debugger.");
         cr_assert_eq(
             dbg.dbgee.state, TERMINATED,
-            "Debuggee state flag should be TERMINATED after free_dbg.");
-        cr_assert_eq(dbg.state, DETACHED,
-                     "Debugger state flag should be DETACHED after free_dbg.");
+            "Debuggee state flag should be TERMINATED after free_debugger.");
+        cr_assert_eq(
+            dbg.state, DETACHED,
+            "Debugger state flag should be DETACHED after free_debugger.");
 }
 
 // NOLINTEND(misc-include-cleaner)

--- a/tests/test_debugger.c
+++ b/tests/test_debugger.c
@@ -1,3 +1,6 @@
+// NOLINTBEGIN(misc-include-cleaner)
+
+#include "debuggee.h"
 #include "debugger.h"
 
 #include <criterion/criterion.h>
@@ -5,77 +8,72 @@
 
 #include "test_macros.h"
 
-#ifndef MOCK_TARGET_PATH
-#define MOCK_TARGET_PATH "../bin/mock_target"
+#ifndef MOCK_DEBUGGEE_PATH
+#define MOCK_DEBUGGEE_PATH "../bin/mock_target"
 #endif
 
-// Function to initialize a debugger instance for testing
-static void init_debugger(debugger *dbg, const char *target_path) {
-        dbg->target_pid = -1;
-        dbg->target_name = target_path;
-        dbg->debugger_state_flag = DEBUGGER_IDLE;
-        dbg->target_state_flag = TARGET_IDLE;
-}
-
-// Redirect stdout and stderr for testing
 void redirect_all_stdout(void) {
         cr_redirect_stdout();
         cr_redirect_stderr();
 }
 
-// Test case for start_target
-Test(debugger, start_target_success) {
+Test(debugger, start_debuggee_success) {
         debugger dbg;
-        init_debugger(&dbg, MOCK_TARGET_PATH);
+        init_dbg(&dbg, MOCK_DEBUGGEE_PATH);
 
-        int result = start_target(&dbg);
-        cr_assert_eq(result, 0, "start_target failed with return value %d",
+        int result = start_debuggee(&dbg);
+        cr_assert_eq(result, 0, "start_debuggee failed with return value %d",
                      result);
 
-        cr_assert_neq(dbg.target_pid, -1, "Target PID was not set.");
-        cr_assert_eq(dbg.target_state_flag, TARGET_RUNNING,
-                     "Target state flag not set to RUNNING.");
+        cr_assert_neq(dbg.dbgee.pid, -1, "Debuggee PID was not set.");
+        cr_assert_eq(dbg.dbgee.state, RUNNING,
+                     "Debuggee state flag not set to RUNNING.");
 
         free_dbg(&dbg);
 }
 
-// Test case for trace_target
-Test(debugger, trace_target_success, .init = redirect_all_stdout) {
+Test(debugger, trace_debuggee_success, .init = redirect_all_stdout) {
         debugger dbg;
-        init_debugger(&dbg, MOCK_TARGET_PATH);
+        init_dbg(&dbg, MOCK_DEBUGGEE_PATH);
 
-        int start_result = start_target(&dbg);
+        int start_result = start_debuggee(&dbg);
         cr_assert_eq(start_result, 0,
-                     "start_target failed with return value %d", start_result);
+                     "start_debuggee failed with return value %d",
+                     start_result);
 
-        int trace_result = trace_target(&dbg);
+        int trace_result = trace_debuggee(&dbg);
         cr_assert_eq(trace_result, 0,
-                     "trace_target failed with return value %d", start_result);
+                     "trace_debuggee failed with return value %d",
+                     trace_result);
 
         cr_assert_eq(
-            dbg.debugger_state_flag, DEBUGGER_RUNNING,
-            "Debugger state should be RUNNING after running trace_target.");
-        cr_assert_eq(dbg.target_state_flag, TARGET_TERMINATED,
-                     "Target state should be TERMINATED after trace_target.");
+            dbg.state, DETACHED,
+            "Debugger state should be DETACHED after running trace_debuggee.");
+        cr_assert_eq(
+            dbg.dbgee.state, TERMINATED,
+            "Debuggee state should be TERMINATED after trace_debuggee.");
 
         free_dbg(&dbg);
 }
 
-// Test case for free_dbg when target is running
-Test(debugger, free_dbg_kill_running_target, .init = redirect_all_stdout) {
+Test(debugger, free_dbg_kill_running_debuggee, .init = redirect_all_stdout) {
         debugger dbg;
-        init_debugger(&dbg, MOCK_TARGET_PATH);
+        init_dbg(&dbg, MOCK_DEBUGGEE_PATH);
 
-        int start_result = start_target(&dbg);
+        int start_result = start_debuggee(&dbg);
         cr_assert_eq(start_result, 0,
-                     "start_target failed with return value %d", start_result);
+                     "start_debuggee failed with return value %d",
+                     start_result);
 
         free_dbg(&dbg);
 
-        cr_assert_eq(dbg.target_pid, -1,
-                     "Target PID should be reset after free_dbg.");
-        cr_assert_eq(dbg.target_state_flag, TARGET_TERMINATED,
-                     "Target state flag should be TERMINATED after free_dbg.");
-        cr_assert_eq(dbg.debugger_state_flag, DEBUGGER_IDLE,
-                     "Debugger state flag should be IDLE after free_dbg.");
+        cr_assert_eq(dbg.dbgee.pid, -1,
+                     "Debuggee PID should be reset after free_dbg.");
+        cr_assert_eq(
+            dbg.dbgee.state, TERMINATED,
+            "Debuggee state flag should be TERMINATED after free_dbg.");
+        cr_assert_eq(dbg.state, DETACHED,
+                     "Debugger state flag should be DETACHED after free_dbg.");
 }
+
+// NOLINTEND(misc-include-cleaner)


### PR DESCRIPTION
When the debugger starts it holds the child process.
When the user enters "run" it continues the execution.

Currently the debugger always waits for user input when WIFSTOPPED(status) is true.
This allows us to add more commands in the future.

Closes #12 