### PR TITLE
Use linenoise for command prompting

### DIFF
--- a/.github/workflows/c.yml
+++ b/.github/workflows/c.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3
+        with:
+          submodules: true
 
       - name: Cache CMake and LLVM
         uses: actions/cache@v3

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "lib/linenoise"]
+	path = lib/linenoise
+	url = https://github.com/antirez/linenoise.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,16 @@ target_link_libraries(z_lib PUBLIC
     ${CAPSTONE_LIBRARIES}
 )
 
+add_library(linenoise STATIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/lib/linenoise/linenoise.c
+)
+
+target_include_directories(linenoise PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/lib/linenoise
+)
+
+target_link_libraries(z_lib PRIVATE linenoise)
+
 add_executable(z ${SRC_DIR}/main.c)
 target_link_libraries(z PRIVATE z_lib)
 set_target_properties(z PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${BIN_DIR})

--- a/include/debugger_commands.h
+++ b/include/debugger_commands.h
@@ -17,6 +17,7 @@ typedef enum {
         DBG_STEP,
         DBG_STEP_OVER,
         DBG_STEP_OUT,
+        CLI_CLEAR,
         UNKNOWN
 } command_t;
 

--- a/include/debugger_commands.h
+++ b/include/debugger_commands.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "debugger.h"
+#include "linenoise.h"
 
 typedef enum {
         CLI_EXIT,
@@ -27,6 +28,7 @@ typedef struct {
 } command_mapping;
 
 command_t get_command_type(const char *command);
+void completion(const char *buf, linenoiseCompletions *lc);
 
 int read_and_handle_user_command(debugger *dbg);
 int handle_user_input(debugger *dbg, command_t cmd_type, const char *arg);

--- a/src/debugger_commands.c
+++ b/src/debugger_commands.c
@@ -1,3 +1,4 @@
+#include "linenoise.h"
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -158,32 +159,10 @@ int read_and_handle_user_command(debugger *dbg) {
         size_t len = 0;
         ssize_t read_len;
 
-        while (true) {
-                printf("Z: ");
-                (void)(fflush(stdout));
-                read_len = getline(&input, &len, stdin);
-                if (read_len == -1) {
-                        if (feof(stdin)) {
-                                free(input);
-                                free_debugger(dbg);
-                                exit(0);
-                        } else {
-                                perror("getlinehbreak");
-                                printf("Failed to read command. Continuing "
-                                       "execution.\n");
-                        }
+        linenoiseHistorySetMaxLen(100);
 
-                        free(input);
-
-                        if (ptrace(PTRACE_CONT, dbg->dbgee.pid, NULL, NULL) ==
-                            -1) {
-                                perror("ptrace CONT");
-                                return EXIT_FAILURE;
-                        }
-
-                        dbg->dbgee.state = RUNNING;
-                        return EXIT_SUCCESS;
-                }
+        while ((input = linenoise("Z: ")) != NULL) {
+                linenoiseHistoryAdd(input);
 
                 input[strcspn(input, "\n")] = '\0';
 

--- a/src/debugger_commands.c
+++ b/src/debugger_commands.c
@@ -25,6 +25,7 @@ static const command_mapping command_map[] = {
     {"step", DBG_STEP},
     {"over", DBG_STEP_OVER},
     {"out", DBG_STEP_OUT},
+    {"clear", CLI_CLEAR},
 };
 
 enum {
@@ -148,6 +149,10 @@ int handle_user_input(debugger *dbg, command_t cmd_type, const char *arg) {
                         printf("Failed to step out.\n");
                 }
                 return DONT_PROMPT_USER_AGAIN;
+
+        case CLI_CLEAR:
+                linenoiseClearScreen();
+                return PROMPT_USER_AGAIN;
 
         default:
                 printf("Unhandled command type.\n");

--- a/src/debugger_commands.c
+++ b/src/debugger_commands.c
@@ -46,6 +46,17 @@ command_t get_command_type(const char *command) {
         return UNKNOWN;
 }
 
+void completion(const char *buf, linenoiseCompletions *lc) {
+        size_t buf_len = strlen(buf);
+        size_t map_size = sizeof(command_map) / sizeof(command_map[0]);
+
+        for (size_t i = 0; i < map_size; ++i) {
+                if (strncmp(buf, command_map[i].command, buf_len) == 0) {
+                        linenoiseAddCompletion(lc, command_map[i].command);
+                }
+        }
+}
+
 int handle_user_input(debugger *dbg, command_t cmd_type, const char *arg) {
         switch (cmd_type) {
         case UNKNOWN:
@@ -165,6 +176,7 @@ int read_and_handle_user_command(debugger *dbg) {
         char *input = NULL;
 
         linenoiseHistorySetMaxLen(LINENOISE_MAX_HISTORY_LENGTH);
+        linenoiseSetCompletionCallback(completion);
 
         while (true) {
                 input = linenoise("Z: ");

--- a/src/debugger_commands.c
+++ b/src/debugger_commands.c
@@ -31,6 +31,7 @@ static const command_mapping command_map[] = {
 enum {
         PROMPT_USER_AGAIN = 1,
         DONT_PROMPT_USER_AGAIN = 0,
+        LINENOISE_MAX_HISTORY_LENGTH = 100,
 };
 
 command_t get_command_type(const char *command) {
@@ -162,21 +163,18 @@ int handle_user_input(debugger *dbg, command_t cmd_type, const char *arg) {
 
 int read_and_handle_user_command(debugger *dbg) {
         char *input = NULL;
-        size_t len = 0;
-        ssize_t read_len;
 
-        linenoiseHistorySetMaxLen(100);
+        linenoiseHistorySetMaxLen(LINENOISE_MAX_HISTORY_LENGTH);
 
         while (true) {
-                if ((input = linenoise("Z: ")) == NULL) {
-                        /* Exit debugger on Ctrl + C*/
+                input = linenoise("Z: ");
+                if (input == NULL) {
                         if (errno == EAGAIN) {
                                 handle_user_input(dbg, CLI_EXIT, "");
-                        } else {
-                                free(input);
-                                free_debugger(dbg);
-                                exit(EXIT_FAILURE);
+                                continue;
                         }
+                        free_debugger(dbg);
+                        exit(EXIT_FAILURE);
                 }
 
                 linenoiseHistoryAdd(input);


### PR DESCRIPTION
This PR implements command prompts with [linenoise](https://github.com/antirez/linenoise#single-line-vs-multi-line-editing) for command history support and tab completion.