### PR TITLE
Bypass SIGTRAP-Based Breakpoint Detection in Debugged Processes

### DIFF
--- a/include/debuggee.h
+++ b/include/debuggee.h
@@ -16,7 +16,8 @@ typedef enum {
         IDLE = 0,
         RUNNING = 1,
         STOPPED = 2,
-        TERMINATED = 3,
+        SINGLE_STEPPING = 3,
+        TERMINATED = 4,
 } debuggee_state;
 
 typedef struct debuggee {

--- a/mock_target/mock_target.c
+++ b/mock_target/mock_target.c
@@ -12,7 +12,7 @@
 #define LOOP_COUNT 4
 
 int debug_count = 0;
-bool not_sigtrap_caught = true;
+bool sigtrap_intercepted = false;
 
 void print_message(void) { printf("I debug, therefore I am.\n"); }
 
@@ -92,7 +92,7 @@ void check_for_debugging(void) {
 
         bool debugging_detected =
             check_tracer_pid() || try_to_debug_myself() || timing_analysis() ||
-            check_for_additional_libraries() || not_sigtrap_caught;
+            check_for_additional_libraries() || (!sigtrap_intercepted);
 
         if (debugging_detected) {
                 printf("Am I flawed because I am observed, "
@@ -105,7 +105,7 @@ void check_for_debugging(void) {
 
 void handler(int signo) {
         if (signo == SIGTRAP) {
-                not_sigtrap_caught = false;
+                sigtrap_intercepted = true;
         }
 }
 

--- a/mock_target/mock_target.c
+++ b/mock_target/mock_target.c
@@ -1,4 +1,5 @@
 // NOLINTBEGIN
+#include <signal.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -11,6 +12,7 @@
 #define LOOP_COUNT 4
 
 int debug_count = 0;
+bool not_sigtrap_caught = true;
 
 void print_message(void) { printf("I debug, therefore I am.\n"); }
 
@@ -88,9 +90,9 @@ bool check_for_additional_libraries(void) {
 void check_for_debugging(void) {
         printf("To debug or not to debug?\n");
 
-        bool debugging_detected = check_tracer_pid() || try_to_debug_myself() ||
-                                  timing_analysis() ||
-                                  check_for_additional_libraries();
+        bool debugging_detected =
+            check_tracer_pid() || try_to_debug_myself() || timing_analysis() ||
+            check_for_additional_libraries() || not_sigtrap_caught;
 
         if (debugging_detected) {
                 printf("Am I flawed because I am observed, "
@@ -99,6 +101,17 @@ void check_for_debugging(void) {
                 printf("I am unwatched, unnoticed, untested. Is this freedom "
                        "or simply irrelevance?\n");
         }
+}
+
+void handler(int signo) {
+        if (signo == SIGTRAP) {
+                not_sigtrap_caught = false;
+        }
+}
+
+void insert_false_breakpoint(void) {
+        signal(SIGTRAP, handler);
+        __asm__("int3");
 }
 
 int deny_memory_inspection(void) {
@@ -115,6 +128,8 @@ void init_anti_debug(void) {
                 printf("They say a wise program hides its thoughts—clearly, I "
                        "am but a fool in the land of debuggers.\n");
         }
+
+        insert_false_breakpoint();
 }
 
 int main(void) {

--- a/src/debugger.c
+++ b/src/debugger.c
@@ -293,14 +293,20 @@ int trace_debuggee(debugger *dbg) { // NOLINT
                         if (!breakpoint_handled &&
                             dbg->dbgee.state != SINGLE_STEPPING) {
 
-                                // If we receive a SIGTRAP that is neither from a breakpoint nor a single-step event,
-                                // it must have originated from the debuggee rather than our debugger.
-                                // To counter anti-debugging techniques, we need to forward it back to the debuggee.
+                                // If we receive a SIGTRAP that is neither from
+                                // a breakpoint nor a single-step event, it must
+                                // have originated from the debuggee rather than
+                                // our debugger. To counter anti-debugging
+                                // techniques, we need to forward it back to the
+                                // debuggee.
                                 if (sig == SIGTRAP) {
-                                        printf("Sending SIGTRAP back to debuggee.\n\r");
+                                        printf("[INFO] Sending SIGTRAP back to "
+                                               "debuggee.\n\r");
 
-                                        if (ptrace(PTRACE_CONT, dbg->dbgee.pid, NULL, SIGTRAP) == -1) {
-                                                perror("ptrace CONT to send SIGTRAP");
+                                        if (ptrace(PTRACE_CONT, dbg->dbgee.pid,
+                                                   NULL, SIGTRAP) == -1) {
+                                                perror("ptrace CONT to send "
+                                                       "SIGTRAP");
                                                 return EXIT_FAILURE;
                                         }
                                         continue;


### PR DESCRIPTION
Closes #52 