### PR TITLE
Fix Segfault, 'main' Requirement & Relative Path Issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ set(CMAKE_C_STANDARD_REQUIRED True)
 set(CMAKE_C_EXTENSIONS OFF)
 
 add_compile_definitions(_POSIX_C_SOURCE=200809L)
+
 add_compile_options(-Wall -Wextra -pedantic)
 
 set(CMAKE_C_COMPILER gcc)

--- a/include/debuggee.h
+++ b/include/debuggee.h
@@ -51,7 +51,7 @@ int SetCatchpoint(debuggee *dbgee, const char *arg);
 int RemoveBreakpoint(debuggee *dbgee, const char *arg);
 void ListBreakpoints(debuggee *dbgee);
 
-unsigned long get_main_absolute_address(debuggee *dbgee);
+unsigned long get_entry_absolute_address(debuggee *dbgee);
 int set_temp_sw_breakpoint(debuggee *dbgee, uint64_t addr);
 bool is_software_breakpoint(debuggee *dbgee, size_t *bp_index_out);
 bool is_hardware_breakpoint(debuggee *dbgee, size_t *bp_index_out);

--- a/src/debugger.c
+++ b/src/debugger.c
@@ -210,18 +210,25 @@ int trace_debuggee(debugger *dbg) { // NOLINT
                         dbg->dbgee.state = STOPPED;
 
                         if (main_startup_breakpoint_set == false) {
-                                unsigned long main_address =
-                                    get_main_absolute_address(&dbg->dbgee);
-
-                                if (main_address == 0) {
+                                unsigned long entry_address =
+                                    get_entry_absolute_address(&dbg->dbgee);
+                                if (entry_address == 0) {
                                         (void)(fprintf(stderr,
-                                                       "Failed to retrieve "
-                                                       "'main' address.\n"));
+                                                       "Failed to retrieve the "
+                                                       "entry point.\n"));
                                         return EXIT_FAILURE;
                                 }
 
-                                set_temp_sw_breakpoint(&dbg->dbgee,
-                                                       main_address);
+                                if (set_temp_sw_breakpoint(&dbg->dbgee,
+                                                           entry_address) !=
+                                    EXIT_SUCCESS) {
+                                        (void)(fprintf(
+                                            stderr,
+                                            "Failed to set temporary "
+                                            "breakpoint at 0x%lx.\n",
+                                            entry_address));
+                                        return EXIT_FAILURE;
+                                }
 
                                 if (ptrace(PTRACE_CONT, dbg->dbgee.pid, NULL,
                                            NULL) == -1) {

--- a/src/main.c
+++ b/src/main.c
@@ -1,22 +1,32 @@
-#include "debugger.h"
-
-#include <limits.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
 
-bool file_exists(const char *filename);
+#include "debugger.h"
+
+bool is_relative_path(const char *filename) { return filename[0] == '.'; }
+
+bool file_exists(const char *filename) {
+        return access(filename, F_OK | X_OK) == 0;
+}
 
 int main(int argc, char **argv) {
         if (argc < 2) {
                 (void)(fprintf(stderr, "Usage: %s <debug_target>\n", argv[0]));
+                return EXIT_FAILURE;
         }
 
         const char *debuggee_name = argv[1];
 
+        if (is_relative_path(debuggee_name)) {
+                (void)(fprintf(stderr, "No relative paths allowed %s\n",
+                               debuggee_name));
+                return EXIT_FAILURE;
+        }
+
         if (!file_exists(debuggee_name)) {
-                (void)(fprintf(stderr, "Cannot find executable %s",
+                (void)(fprintf(stderr, "Cannot find executable %s\n",
                                debuggee_name));
                 return EXIT_FAILURE;
         }
@@ -38,11 +48,4 @@ int main(int argc, char **argv) {
 
         free_debugger(&dbg);
         return EXIT_SUCCESS;
-}
-
-bool file_exists(const char *filename) {
-        if (filename[0] == '.') {
-                return false;
-        }
-        return access(filename, F_OK | X_OK) == 0;
 }


### PR DESCRIPTION
Fixes:
- Running ./z without arguments segfaults instead of showing usage.
- Debugging executables without main fails, but main isn't required.
- Relative paths (e.g., ./mock_target) aren't resolved properly.
