### PR TITLE
Run Anti-Anti-Debugger with Valgrind and Fix Potential Issues

### DIFF
--- a/include/debuggee.h
+++ b/include/debuggee.h
@@ -59,7 +59,9 @@ bool is_catchpoint_signal(debuggee *dbgee, size_t *bp_index_out,
                           int signal_number);
 bool is_catchpoint_event(debuggee *dbgee, size_t *bp_index_out,
                          unsigned long event_code);
+bool is_watchpoint(debuggee *dbgee, size_t *bp_index_out);
 int handle_software_breakpoint(debuggee *dbgee, size_t bp_index);
 int handle_hardware_breakpoint(debuggee *dbgee, size_t bp_index);
 int handle_catchpoint_signal(debuggee *dbgee, size_t bp_index);
 int handle_catchpoint_event(debuggee *dbgee, size_t bp_index);
+int handle_watchpoint(debuggee *dbgee, size_t bp_index);

--- a/src/debugger.c
+++ b/src/debugger.c
@@ -81,6 +81,7 @@ void init_debugger(debugger *dbg, const char *debuggee_name) {
         dbg->dbgee.pid = -1;
         dbg->dbgee.name = debuggee_name;
         dbg->dbgee.state = IDLE;
+        dbg->dbgee.has_run = false;
 
         // Could be NULL. TODO: Catch this.
         dbg->dbgee.bp_handler = init_breakpoint_handler();

--- a/src/debugger.c
+++ b/src/debugger.c
@@ -245,6 +245,7 @@ int trace_debuggee(debugger *dbg) { // NOLINT
                         size_t sw_bp_index;
                         size_t hw_bp_index;
                         size_t cp_signal_index;
+                        size_t wp_index;
                         bool breakpoint_handled = false;
 
                         if (is_software_breakpoint(&dbg->dbgee, &sw_bp_index)) {
@@ -270,6 +271,14 @@ int trace_debuggee(debugger *dbg) { // NOLINT
                                 breakpoint_handled = true;
                                 if (handle_catchpoint_signal(&dbg->dbgee,
                                                              cp_signal_index) !=
+                                    EXIT_SUCCESS) {
+                                        return EXIT_FAILURE;
+                                }
+                        }
+
+                        if (is_watchpoint(&dbg->dbgee, &wp_index)) {
+                                breakpoint_handled = true;
+                                if (handle_watchpoint(&dbg->dbgee, wp_index) !=
                                     EXIT_SUCCESS) {
                                         return EXIT_FAILURE;
                                 }


### PR DESCRIPTION
- Added is_watchpoint and handle_watchpoint function
- Fix: Conditional jump or move depends on unitialised value (has_run)

Note: We ignore: blocks are still reachable (from linenoise)


Closes #42